### PR TITLE
Adding pattern-matching over records defined in another module

### DIFF
--- a/compiler/ast.ml
+++ b/compiler/ast.ml
@@ -103,6 +103,7 @@ and pat_field_ =
   | PFany
   | PFid of id 
   | PField of id * pat
+  | PQualField of id * id * pat
 
 and expr = Pos.t * expr_
 and expr_ = 

--- a/compiler/naming.ml
+++ b/compiler/naming.ml
@@ -604,6 +604,14 @@ and pat_field_ genv env = function
   | PField (id, p) ->
       let env, p = pat genv env p in
       env, Nast.PField (Env.field env id, p)
+  | PQualField (md_id, id, p) ->
+      let md_id = Genv.module_id genv md_id in
+      (*let _ = print_endline ("md_id - " ^ Ident.debug (snd md_id)) in*)
+      let sig_md = Genv.sig_ genv md_id in
+      let id = Env.field sig_md id in
+      (*let _ = print_endline ("id    - " ^ Ident.debug (snd id)) in*)
+      let env, p = pat genv env p in
+      env, Nast.PField (id, p)
 
 and tpat_list genv env idl =
   let env = Env.fresh_tvars env in

--- a/compiler/parser.mly
+++ b/compiler/parser.mly
@@ -313,8 +313,10 @@ field_type:
 
 pat_field:
 | ID { fst $1, PFid $1 }
-| ID EQ pat { btw $1 $3, PField ($1, $3) } 
+| ID EQ pat { btw $1 $3, PField ($1, $3) }
+| CSTR DOT ID EQ pat { btw $1 $5, PQualField ($1, $3, $5) }
 | TILD ID { Pos.btw $1 (fst $2), PField ($2, (fst $2, Pid $2)) }
+| TILD CSTR DOT ID { btw $2 $4, PQualField ($2, $4, (fst $4, Pid $4)) }
 | UNDERSCORE { ($1, PFany) }
 
 pat_field_l:

--- a/stdlib/liml.h
+++ b/stdlib/liml.h
@@ -2,6 +2,9 @@
 
 #include <stdlib.h>
 
+// Option.None - machine representation
+#define NONE 1
+
 #ifdef ARCH_32
 
 typedef lint   lvalue ;

--- a/stdlib/print.c
+++ b/stdlib/print.c
@@ -2,8 +2,16 @@
 #include<stdio.h>
 
 lvalue print_int(lvalue n__){
-  int n = (int) n__ ;
+  lint n = (lint) n__ ;
+
+#ifdef ARCH_32
   printf("%d", n) ;
+#endif
+
+#ifdef ARCH_64
+  printf("%ld", n) ;
+#endif
+
   return 0 ;
 }
 
@@ -13,7 +21,7 @@ lvalue print_newline(){
 }
 
 lvalue print_float(lvalue x__){
-  float x = V2F(x__) ;
+  lfloat x = V2F(x__) ;
   printf("%f", x) ;
   return 0 ;
 }

--- a/stdlib/share.c
+++ b/stdlib/share.c
@@ -22,17 +22,18 @@ lvalue share_clone(lvalue v_){
 
 lvalue share_release(lvalue v_){
   share_t *x = (share_t *)v_ ;
-  __sync_fetch_and_sub(&x->counter, 1) ;
   if (x->counter == 1){
     lvalue *res = malloc(sizeof(lvalue));
     *res = x->value ;
     free(x) ;
-    return res ;
+    
+    return (lvalue)res ;
   }
-  // Option.None machine representation is 1
-  return (lvalue) 1 ;
+  
+  __sync_fetch_and_sub(&x->counter, 1) ;
+  return (lvalue) NONE ;
 }
 
-void* share_visit(share_t* x){
-  return x->value ;
+lvalue share_visit(share_t* x){
+  return (lvalue) x->value ;
 }

--- a/stdlib/share.c
+++ b/stdlib/share.c
@@ -4,29 +4,33 @@
 
 typedef struct{
   lvalue counter ;
-  void* value ;
+  lvalue value ;
 } share_t ;
 
-share_t* share_make(void* value){
+lvalue share_make(lvalue value){
   share_t *res = malloc(sizeof(share_t)) ;
   res->counter = 1 ;
   res->value = value ;
-  return res ;
+  return (lvalue) res ;
 }
 
-share_t* share_clone(share_t* x){
+lvalue share_clone(lvalue v_){
+  share_t *x = (share_t *)v_ ;
   __sync_fetch_and_add(&x->counter, 1) ;
-  return x ;
+  return (lvalue) x ;
 }
 
-void** share_release(share_t* x){
+lvalue share_release(lvalue v_){
+  share_t *x = (share_t *)v_ ;
   __sync_fetch_and_sub(&x->counter, 1) ;
   if (x->counter == 1){
-    void** res = malloc(sizeof(lvalue));
+    lvalue *res = malloc(sizeof(lvalue));
     *res = x->value ;
+    free(x) ;
     return res ;
   }
-  return NULL ;
+  // Option.None machine representation is 1
+  return (lvalue) 1 ;
 }
 
 void* share_visit(share_t* x){

--- a/test/test_record.lml
+++ b/test/test_record.lml
@@ -1,0 +1,28 @@
+module Roo = struct
+
+    type leap = { height : float; length : float }
+
+    val main : unit -> unit
+    let main () =
+        let l = { height = 3.0; length = 6.0 } in
+        let { l; height = height } = l in
+        let { l; ~length } = l in
+        free l;
+        Print.float height; Print.newline ();
+        Print.float length; Print.newline ()
+
+end
+
+
+module Christopher = struct
+
+    val main : unit -> unit
+    let main () = 
+        let l = { Roo.height = 3.0; Roo.length = 6.0 } in
+        let { l; Roo.height = height } = l in
+        let { l; ~Roo.length } = l in
+        free l;
+        Print.float height; Print.newline ();
+        Print.float length; Print.newline ()
+
+end


### PR DESCRIPTION
Example:

```
    let l = { Roo.height = 3.0; Roo.length = 6.0 } in  (* this was woiking, the lines below weren't *)
    let { l; Roo.height = height } = l in
    let { l; ~Roo.length } = l in
```
