### PR TITLE
Llvm Bindings installed via Opam

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 I am providing code in this repository to you under an open source license.
-Because this is my personal repository, the license you receive to my code if from
+Because this is my personal repository, the license you receive to my code is from
 me and not my employer (Facebook).
 
 LinearML (or LiML) is a programming language designed to write efficient parallel programs.

--- a/configure
+++ b/configure
@@ -325,7 +325,7 @@ llc_version=`$llc -version | grep version` ;
 if [[ "$llc_version" =~ .*version.3.*.* ]]; then
     echo -e "Checking llc     \t: OK$llc_version"
 else
-    echo "Bad version of llc (expected version 2.8): $version" 2>&1;
+    echo "Bad version of llc (expected version 2.8): $llc_version" 2>&1;
     exit 2
 fi
 
@@ -333,7 +333,7 @@ opt_version=`$opt -version | grep version` ;
 if [[ "$opt_version" =~ .*version.3.*.* ]]; then
     echo -e "Checking opt     \t: OK$opt_version"
 else
-    echo "Bad version of opt (expected version 3.0): $version" 2>&1;
+    echo "Bad version of opt (expected version 3.0): $opt_version" 2>&1;
     exit 2
 fi
 
@@ -341,7 +341,7 @@ ocamlc_version=`$ocamlc -version` ;
 if [[ "$ocamlc_version" =~ 4.0[0|1].* ]]; then
     echo -e "Checking ocamlc  \t: OK $ocamlc_version"
 else
-    echo "Bad version of ocamlc (< 3.11): $version" 2>&1;
+    echo "Bad version of ocamlc (< 3.11): $ocamlc_version" 2>&1;
     exit 2
 fi
 
@@ -349,7 +349,7 @@ ocamlopt_version=`$ocamlopt -version` ;
 if [[ "$ocamlopt_version" =~ 4.0[0|1].* ]]; then
     echo -e "Checking ocamlopt\t: OK $ocamlopt_version"
 else
-    echo "Bad version of ocamlopt (< 3.11): $version" 2>&1;
+    echo "Bad version of ocamlopt (< 3.11): $ocamlopt_version" 2>&1;
     exit 2
 fi
 
@@ -357,7 +357,7 @@ ocamllex_version=`$ocamllex -version` ;
 if [[ "$ocamllex_version" =~ 4.0[0|1].* ]]; then
     echo -e "Checking ocamllex\t: OK $ocamllex_version"
 else
-    echo "Bad version of ocamllex (< 4.00): $version" 2>&1;
+    echo "Bad version of ocamllex (< 4.00): $ocamllex_version" 2>&1;
     exit 2
 fi
 
@@ -365,7 +365,7 @@ ocamlyacc_version=`$ocamlyacc -version` ;
 if [[ "$ocamlyacc_version" =~ 4.0[0|1].* ]]; then
     echo -e "Checking ocamlyacc\t: OK $ocamlyacc_version"
 else
-    echo "Bad version of ocamlyacc (< 3.11): $version" 2>&1;
+    echo "Bad version of ocamlyacc (< 3.11): $ocamlyacc_version" 2>&1;
     exit 2
 fi
 
@@ -373,7 +373,7 @@ ocamldep_version=`$ocamldep -version` ;
 if [[ "$ocamldep_version" =~ 4.0[0|1].* ]]; then
     echo -e "Checking ocamldep\t: OK $ocamldep_version"
 else
-    echo "Bad version of ocamldep (< 3.11): $version" 2>&1;
+    echo "Bad version of ocamldep (< 3.11): $ocamldep_version" 2>&1;
     exit 2
 fi
 

--- a/configure
+++ b/configure
@@ -216,6 +216,10 @@ if [ $os = "Darwin" ]; then
    llvm_target_cma_base="target"
 fi
 
+if  test -d "$(opam config var lib)/llvm/"; then
+    llbindings="$(opam config var lib)/llvm/"
+fi
+
 if test "$llbindings"; then
     llvm_cma="$llbindings/llvm.cma";
     llvm_analysis_cma="$llbindings/llvm_analysis.cma"


### PR DESCRIPTION
I added support for llvm bindings installed via the Ocaml Package Manager (opam) in the configure file as well as changing some undefined $version variables to their intended counterparts.
